### PR TITLE
Add porting notes for Edge of Time

### DIFF
--- a/Implement.md
+++ b/Implement.md
@@ -1,0 +1,19 @@
+# Edge of Time Porting Notes
+
+This repository currently targets **Sonic Unleashed**. To adapt it for *Spider-Man: Edge of Time* some high level tasks are required:
+
+- Replace all references to the Unleashed XEX with the Edge of Time XEX.
+- Update build scripts and configuration files with function addresses for the new game.
+- Remove Sonic-specific assets and localisation entries.
+- Review each subfolder for additional changes; see the Implement.md in each directory for specifics.
+
+Known general work items:
+
+- Start finding kernel call offsets.
+- Fix boundary issues in guest memory handling.
+- Ensure base XEX is mapped correctly so guest/host exchanges work.
+- Strip Sonic specific code from everything except the GPU modules when starting.
+- Label every possible function in Ghidra/IDA for easier debugging.
+- Implement missing kernel calls and objects.
+- Reverse engineer where shaders are and add extraction tooling.
+- Extend the build system to run shader extraction and recompilation.

--- a/reblue/Implement.md
+++ b/reblue/Implement.md
@@ -1,0 +1,9 @@
+# Porting reblue Runtime
+
+The `reblue` folder contains the runtime used to launch the game. Changes needed for Edge of Time include:
+
+- Update `main.cpp` to mount the Edge of Time content directory and load its XEX.
+- Replace Unleashed titles and registry keys with Edge of Time equivalents.
+- Remove or refactor Sonic specific UI and resource references.
+- Ensure GPU and APU modules handle Edge of Time assets correctly.
+- Additional kernel and memory mapping work may be required as offsets differ.

--- a/reblue/apu/Implement.md
+++ b/reblue/apu/Implement.md
@@ -1,0 +1,7 @@
+# Audio System Tasks
+
+Edge of Time may use different channel layouts or audio initialization. Work here includes:
+
+- Update `SDL_SetHint` values to use the Edge of Time name.
+- Verify the audio callback behaves correctly with Edge of Time's XMA streams.
+- Fix any buffer boundary issues when streaming music or sound effects.

--- a/reblue/cpu/Implement.md
+++ b/reblue/cpu/Implement.md
@@ -1,0 +1,7 @@
+# CPU Emulation Notes
+
+Edge of Time will have different function addresses and potentially different thread setup requirements.
+
+- Determine new entry point and guest thread parameters.
+- Validate guest stack layout and fix any boundary issues.
+- Label all new functions discovered via IDA or Ghidra for easier debugging.

--- a/reblue/gpu/Implement.md
+++ b/reblue/gpu/Implement.md
@@ -1,0 +1,7 @@
+# GPU Considerations
+
+The GPU module handles rendering and shader management.
+
+- Identify Edge of Time shader locations and update the cache.
+- Remove Sonic Unleashed specific rendering paths from the build list.
+- Implement shader extraction and recompilation stages for the new game.

--- a/reblue/hid/Implement.md
+++ b/reblue/hid/Implement.md
@@ -1,0 +1,6 @@
+# Input Changes
+
+Edge of Time might use different controller mappings.
+
+- Check driver initialization for compatibility with the game's input needs.
+- Update button layouts and mapping tables if necessary.

--- a/reblue/kernel/Implement.md
+++ b/reblue/kernel/Implement.md
@@ -1,0 +1,7 @@
+# Kernel Layer Tasks
+
+A number of kernel calls differ between titles. For Edge of Time:
+
+- Discover offsets for kernel imports and update `imports.cpp`.
+- Map any new kernel objects used by the game.
+- Verify memory mapping so host/guest data exchanges occur correctly.

--- a/reblue/locale/Implement.md
+++ b/reblue/locale/Implement.md
@@ -1,0 +1,5 @@
+# Localisation Updates
+
+- Replace any strings mentioning "Unleashed" with the Edge of Time branding.
+- Audit all installer and options menu text for game specific references.
+- New text may be required for features unique to Edge of Time.

--- a/reblue/os/Implement.md
+++ b/reblue/os/Implement.md
@@ -1,0 +1,5 @@
+# Operating System Layer
+
+- Change registry paths to avoid collision with Unleashed settings.
+- Verify any platform specific process calls still succeed with the new binary.
+- Rework user path generation if the game expects different directory layouts.

--- a/reblue/res/Implement.md
+++ b/reblue/res/Implement.md
@@ -1,0 +1,6 @@
+# Resource Build Files
+
+The `res` directory holds version information and Windows resources.
+
+- Update `version.txt` and templates with the new product name.
+- Replace icons or assets that show Sonic branding.

--- a/reblue/res/win32/Implement.md
+++ b/reblue/res/win32/Implement.md
@@ -1,0 +1,4 @@
+# Windows Resource Template
+
+- Change ProductName and FileDescription fields to Edge of Time.
+- Adjust icons and version strings accordingly.

--- a/reblue/ui/Implement.md
+++ b/reblue/ui/Implement.md
@@ -1,0 +1,5 @@
+# UI Adjustments
+
+- Update window titles from "Unleashed Recompiled" to Edge of Time.
+- Swap any Unleashed themed imagery in the installer and menus.
+- Ensure resolution and aspect ratios match Edge of Time assets.

--- a/reblue/user/Implement.md
+++ b/reblue/user/Implement.md
@@ -1,0 +1,5 @@
+# User Configuration
+
+- Rename `USER_DIRECTORY` to reflect the new project name.
+- Add new configuration options if Edge of Time exposes additional settings.
+- Verify save path and registry integration works with the game's profile data.

--- a/rebluelib/Implement.md
+++ b/rebluelib/Implement.md
@@ -1,0 +1,8 @@
+# Porting rebluelib to Edge of Time
+
+`rebluelib` contains the recompiler and configuration used to load the original XEX. To target Edge of Time:
+
+- Replace `private/default.xex` with the Edge of Time executable.
+- Update `config/config.toml` with new PPC function addresses.
+- Review `CMakeLists.txt` for any hard coded paths or Unleashed references.
+- Enable shader extraction in the build once the pack format is understood.

--- a/resources/Implement.md
+++ b/resources/Implement.md
@@ -1,0 +1,5 @@
+# Resource Changes
+
+- Replace images, icons, sounds and fonts that reference Sonic Unleashed.
+- Provide Edge of Time specific assets where required.
+- Ensure any pack files match the new game's expected format.

--- a/scripts/Implement.md
+++ b/scripts/Implement.md
@@ -1,0 +1,5 @@
+# Script Updates
+
+- Modify `bluedragon.bms` or provide a new QuickBMS script for Edge of Time pack files.
+- Adjust the IDA helper scripts if function signatures differ.
+- Integrate shader extraction steps into the build system.

--- a/tools/Implement.md
+++ b/tools/Implement.md
@@ -1,0 +1,4 @@
+# Tools Directory
+
+- Verify each helper tool (e.g., file converters, decompression) supports Edge of Time resources.
+- Add utilities for unpacking and rebuilding shader caches.


### PR DESCRIPTION
## Summary
- add Implement.md notes across the project outlining work to port the runtime to **Edge of Time**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685daaebb3f88325ab14b645162642a0