### PR TITLE
Enable GPU sources in reblue build

### DIFF
--- a/reblue/CMakeLists.txt
+++ b/reblue/CMakeLists.txt
@@ -74,13 +74,13 @@ set(REBLUE_CPU_CXX_SOURCES
     "cpu/guest_thread.cpp"
 )
 
-#set(REBLUE_GPU_CXX_SOURCES
-#    "gpu/video.cpp"
-#    "gpu/imgui/imgui_common.cpp"
-#    "gpu/imgui/imgui_font_builder.cpp"
-#    "gpu/imgui/imgui_snapshot.cpp"
-#    "gpu/rhi/plume_vulkan.cpp"
-#)
+set(REBLUE_GPU_CXX_SOURCES
+    "gpu/video.cpp"
+    "gpu/imgui/imgui_common.cpp"
+    "gpu/imgui/imgui_font_builder.cpp"
+    "gpu/imgui/imgui_snapshot.cpp"
+    "gpu/rhi/plume_vulkan.cpp"
+)
 
 #if (UNLEASHED_RECOMP_D3D12)
 #   list(APPEND REBLUE_GPU_CXX_SOURCES
@@ -193,7 +193,7 @@ set(REBLUE_CXX_SOURCES
     ${REBLUE_LOCALE_CXX_SOURCES}
     ${REBLUE_OS_CXX_SOURCES}
     ${REBLUE_CPU_CXX_SOURCES}
-#    ${REBLUE_GPU_CXX_SOURCES}
+    ${REBLUE_GPU_CXX_SOURCES}
     ${REBLUE_APU_CXX_SOURCES}
     ${REBLUE_HID_CXX_SOURCES}
     ${REBLUE_UI_CXX_SOURCES}


### PR DESCRIPTION
## Summary
- include GPU source files in `reblue`
- link GPU sources into main target

## Testing
- `cmake ..` *(fails: could not find `directx-dxc` package)*
- `cmake --build .` *(fails: no `Makefile` generated)*

------
https://chatgpt.com/codex/tasks/task_e_685e1e16fba48325887595425a1cb883