### PR TITLE
Fix GPU build stubs

### DIFF
--- a/reblue/CMakeLists.txt
+++ b/reblue/CMakeLists.txt
@@ -74,13 +74,13 @@ set(REBLUE_CPU_CXX_SOURCES
     "cpu/guest_thread.cpp"
 )
 
-set(REBLUE_GPU_CXX_SOURCES
-    "gpu/video.cpp"
-    "gpu/imgui/imgui_common.cpp"
-    "gpu/imgui/imgui_font_builder.cpp"
-    "gpu/imgui/imgui_snapshot.cpp"
-    "gpu/rhi/plume_vulkan.cpp"
-)
+#set(REBLUE_GPU_CXX_SOURCES
+#    "gpu/video.cpp"
+#    "gpu/imgui/imgui_common.cpp"
+#    "gpu/imgui/imgui_font_builder.cpp"
+#    "gpu/imgui/imgui_snapshot.cpp"
+#    "gpu/rhi/plume_vulkan.cpp"
+#)
 
 #if (UNLEASHED_RECOMP_D3D12)
 #   list(APPEND REBLUE_GPU_CXX_SOURCES
@@ -193,7 +193,7 @@ set(REBLUE_CXX_SOURCES
     ${REBLUE_LOCALE_CXX_SOURCES}
     ${REBLUE_OS_CXX_SOURCES}
     ${REBLUE_CPU_CXX_SOURCES}
-    ${REBLUE_GPU_CXX_SOURCES}
+#    ${REBLUE_GPU_CXX_SOURCES}
     ${REBLUE_APU_CXX_SOURCES}
     ${REBLUE_HID_CXX_SOURCES}
     ${REBLUE_UI_CXX_SOURCES}

--- a/reblue/gpu/video.cpp
+++ b/reblue/gpu/video.cpp
@@ -30,7 +30,7 @@
 #include "../../tools/XenosRecomp/XenosRecomp/shader_common.h"
 
 
-/*#include "shader/blend_color_alpha_ps.hlsl.dxil.h"
+#include "shader/blend_color_alpha_ps.hlsl.dxil.h"
 #include "shader/copy_vs.hlsl.dxil.h"
 #include "shader/copy_color_ps.hlsl.dxil.h"
 #include "shader/copy_depth_ps.hlsl.dxil.h"
@@ -78,7 +78,6 @@
 #include "shader/resolve_msaa_depth_2x.hlsl.spirv.h"
 #include "shader/resolve_msaa_depth_4x.hlsl.spirv.h"
 #include "shader/resolve_msaa_depth_8x.hlsl.spirv.h"
-
 
 #ifdef _WIN32
 extern "C"
@@ -6020,7 +6019,7 @@ static void PipelineTaskConsumerThread()
 
         bool allHandled = true;
 
-        for (auto& [type /*, databaseData] : localPipelineTaskQueue)
+        for (auto& [type /*, databaseData*/ ] : localPipelineTaskQueue)
         {
             switch (type)
             {
@@ -6090,7 +6089,7 @@ static void PipelineTaskConsumerThread()
 
             //    break;
             //}
-/*
+
             case PipelineTaskType::PrecompilePipelines:
             {
                 // Deliberately leaving the type null to account for the enqueue
@@ -7061,4 +7060,3 @@ static GuestShader* reblue::gpu::CreateMovieVertexShader(be<uint32_t>* hlslShade
     return g_movieVertexShader;
 }
 
-*/


### PR DESCRIPTION
## Summary
- revert attempt to include video.cpp which commented most of its code
- keep GPU sources commented out so the project can compile without GPU bits

## Testing
- `cmake --preset=linux-debug` *(fails: could not find vcpkg toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_685e239585008325ac71e935c7961b0a