### PR TITLE
Disable D3D12 by default

### DIFF
--- a/reblue/CMakeLists.txt
+++ b/reblue/CMakeLists.txt
@@ -1,7 +1,7 @@
 project("reblue")
 
 if (WIN32)
-    option(UNLEASHED_RECOMP_D3D12 "Add D3D12 support for rendering" ON)
+    option(UNLEASHED_RECOMP_D3D12 "Add D3D12 support for rendering" OFF)
 endif()
 
 add_compile_options(

--- a/reblue/gpu/video.h
+++ b/reblue/gpu/video.h
@@ -16,7 +16,7 @@
 #define LOAD_ZSTD_TEXTURE(name) LoadTexture(decompressZstd(name, name##_uncompressed_size).get(), name##_uncompressed_size)
 
 #define PSO_CACHING
-#define UNLEASHED_RECOMP_D3D12
+//#define UNLEASHED_RECOMP_D3D12
 
 using namespace plume;
 


### PR DESCRIPTION
## Summary
- disable Direct3D 12 support
  - comment out `UNLEASHED_RECOMP_D3D12` in `video.h`
  - set CMake option `UNLEASHED_RECOMP_D3D12` default to OFF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ebd9414948325bee0a2488a38602f