### PR TITLE
Copy dxcompiler.dll

### DIFF
--- a/reblue/CMakeLists.txt
+++ b/reblue/CMakeLists.txt
@@ -283,6 +283,9 @@ if (UNLEASHED_RECOMP_D3D12)
     find_file(DIRECTX_DXIL_LIBRARY "dxil.dll")
     file(COPY ${DIRECTX_DXIL_LIBRARY} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+    find_file(DIRECTX_DXCOMPILER_LIBRARY "dxcompiler.dll")
+    file(COPY ${DIRECTX_DXCOMPILER_LIBRARY} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
     target_link_libraries(reblue PRIVATE
         Microsoft::DirectX-Headers 
         Microsoft::DirectX-Guids 


### PR DESCRIPTION
## Summary
- copy dxcompiler.dll for D3D12 builds

## Testing
- `cmake -S reblue -B build -DUNLEASHED_RECOMP_D3D12=ON` *(fails: Could not find a package configuration file provided by "directx-headers")*

------
https://chatgpt.com/codex/tasks/task_e_685f2272ba648325b5d9edae8b3de734