### PR TITLE
Implement simple file loader

### DIFF
--- a/reblue/main.cpp
+++ b/reblue/main.cpp
@@ -41,6 +41,22 @@ reblue::kernel::GuestHeap reblue::kernel::g_userHeap;
 XDBFWrapper g_xdbfWrapper;
 std::unordered_map<uint16_t, GuestTexture*> g_xdbfTextureCache;
 
+static std::vector<uint8_t> LoadFile(const std::filesystem::path& path)
+{
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file)
+        return {};
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(size));
+    if (!file.read(reinterpret_cast<char*>(buffer.data()), size))
+        return {};
+
+    return buffer;
+}
+
 uint32_t LdrLoadModule(const std::filesystem::path &path)
 {
     auto loadResult = LoadFile(path);


### PR DESCRIPTION
## Summary
- add a utility function `LoadFile` in `reblue/main.cpp` for reading files into memory
- reuse the function to load the game module

## Testing
- `cmake -S . -B build` *(fails: VCPKG_ROOT is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f68c9fbb08325bd758125a70969de